### PR TITLE
add empty group after \LaTeX to avoid missing spaces

### DIFF
--- a/Source/main.tex
+++ b/Source/main.tex
@@ -77,7 +77,7 @@ Lecture 1
 
 \begin{frame}{Resources}
     \begin{itemize}
-        \item \href{https://www.latex-project.org/help/documentation/usrguide.pdf}{User Guide}. \textit{The \LaTeX Project}.
+        \item \href{https://www.latex-project.org/help/documentation/usrguide.pdf}{User Guide}. \textit{The \LaTeX{} Project}.
         \item \href{https://en.wikibooks.org/wiki/LaTeX}{\LaTeX}. \textit{Wikibooks}.
         \item \href{https://www.overleaf.com/learn}{Documentation}. \textit{Overleaf}.
         \item \href{https://www.learnlatex.org/en/}{Learn \LaTeX}.
@@ -89,13 +89,13 @@ Lecture 1
 
 \begin{frame}{What is \LaTeX?}
     \begin{itemize}
-        \item \LaTeX is a markup language for typesetting documents
+        \item \LaTeX{} is a markup language for typesetting documents
         \item It excels at math notation, multiple figures, \& large documents
         \item Not a WYSIWYG word processor like Microsoft Word, Google Docs, Apple Pages, Adobe InDesign, \textit{etc}.
         \item The code \textit{describing} your document's style and its content is compiled into a file
         \begin{itemize}
             \item Typically \href{https://en.wikipedia.org/wiki/PDF}{PDF} but \href{https://en.wikipedia.org/wiki/PostScript}{PostScript}, \href{https://en.wikipedia.org/wiki/Rich_Text_Format}{RTF}, \href{https://en.wikipedia.org/wiki/HTML}{HTML}, \href{https://en.wikipedia.org/wiki/Scalable_Vector_Graphics}{SVG} possible
-            \item Converting to Microsoft Word ``.doc'' or ``.docx'' is notoriously painful: \LaTeX $\rightarrow$ PDF $\rightarrow$ Adobe Acrobat $\rightarrow$ Microsoft Word
+            \item Converting to Microsoft Word ``.doc'' or ``.docx'' is notoriously painful: \LaTeX{} $\rightarrow$ PDF $\rightarrow$ Adobe Acrobat $\rightarrow$ Microsoft Word
         \end{itemize}
     \end{itemize}
 \end{frame}
@@ -279,7 +279,7 @@ Lecture 1
 
 \begin{frame}[fragile]{Packages}
     \begin{itemize}
-        \item Packages change and improve how default \LaTeX works
+        \item Packages change and improve how default \LaTeX{} works
         \begin{itemize}
             \item Downloading and configuring packages locally will quickly make you want to use IDEs or cloud services offering package management
         \end{itemize}
@@ -342,7 +342,7 @@ Lecture 1
 
 \begin{frame}[fragile]{Sections: Basics}
     \begin{itemize}
-        \item \LaTeX provides a few levels of sections (top to bottom):
+        \item \LaTeX{} provides a few levels of sections (top to bottom):
         \begin{enumerate}
             \item \verb|\chapter| (specific to \texttt{book} and \texttt{report} classes)
             \item \verb|\section| (typically the top-level in an \texttt{article} manuscript)
@@ -609,7 +609,7 @@ Lecture 1
             \item \texttt{\&} column separator
             \item \texttt{\textbackslash\textbackslash} new row
         \end{itemize}
-        \item There is a zen to creating \LaTeX tables by hand, but...
+        \item There is a zen to creating \LaTeX{} tables by hand, but...
         \begin{itemize}
             \item \texttt{\href{https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_latex.html}{.to\_latex()}} for pandas, \texttt{\href{https://cran.r-project.org/web/packages/stargazer/}{stargazer}} for R, \texttt{\href{http://www.ctan.org/tex-archive/support/excel2latex/}{excel2latex}} for Excel
             \item Web generators like \href{https://www.tablesgenerator.com/}{tablesgenerator.com} and \href{https://www.latex-tables.com/}{latex-tables.com}


### PR DESCRIPTION
i just had a short look and stubled accross some missing spaces I thought it's faster to send you a PR instead of only telling you about it